### PR TITLE
프로젝트 상세 페이지 정보탭 UI

### DIFF
--- a/src/components/MemberCard.vue
+++ b/src/components/MemberCard.vue
@@ -1,0 +1,70 @@
+<!--
+ * fileName       : MemberCard
+ * author         : JooYoon
+ * date           : 2024-09-01
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-09-01           JooYoon           최초 생성
+-->
+
+<template>
+    <v-card class="ma-2" outlined rounded="lg" style="width: 300px">
+        <v-card-text class="pa-3">
+            <div class="d-flex mb-3">
+                <v-avatar size="100" class="mr-3" tile rounded="xxl">
+                    <v-img :src="member.memberImg" :alt="member.memberNickname"></v-img>
+                </v-avatar>
+                <div class="d-flex flex-column justify-center flex-grow-1">
+                    <div class="d-flex align-center justify-center mb-1">
+                        <span class="text-h5 font-weight-bold black--text">{{ member.memberNickname }}</span>
+                        <v-btn icon :href="member.memberGithub" target="_blank" color="black" x-small class="ml-1">
+                            <v-icon>mdi-github</v-icon>
+                        </v-btn>
+                    </div>
+                    <div class="d-flex justify-center">
+                        <v-btn color="brown" dark small class="font-weight-light" style="width: 60%">1:1 채팅</v-btn>
+                    </div>
+                </div>
+            </div>
+
+            <div class="mt-3">
+                <div class="caption black--text mb-1">진행 중인 프로젝트: {{ member.ongoingProjectCount }}개</div>
+                <div class="caption black--text mb-2">완료한 프로젝트: {{ member.completedProjectCount }}개</div>
+                <div class="caption font-weight-bold black--text mb-1 text-h6">기술 스택</div>
+                <div class="d-flex flex-wrap">
+                    <template v-for="tech in member.techStack">
+                        <div v-if="tech.imgUrl" :key="tech.name" class="ma-1 tech-item">
+                            <v-avatar size="32" class="mb-1">
+                                <v-img :src="tech.imgUrl" :alt="tech.name"></v-img>
+                            </v-avatar>
+                            <div class="caption text-center black--text">#{{ tech.name }}</div>
+                        </div>
+                        <v-chip v-else :key="tech.name" class="ma-1" x-small outlined color="black"> #{{ tech.name }} </v-chip>
+                    </template>
+                </div>
+            </div>
+        </v-card-text>
+    </v-card>
+</template>
+
+<script>
+export default {
+    name: 'MemberCard',
+    props: {
+        member: {
+            type: Object,
+            required: true,
+        },
+    },
+};
+</script>
+
+<style scoped>
+.tech-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 50px;
+}
+</style>

--- a/src/components/ProjectInfo.vue
+++ b/src/components/ProjectInfo.vue
@@ -1,0 +1,100 @@
+<!--
+ * fileName       : ProjectInfo
+ * author         : JooYoon
+ * date           : 2024-08-28
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-08-28        JooYoon       최초 생성
+-->
+<template>
+    <v-container>
+        <v-row>
+            <v-col cols="12">
+                <h2>리더 정보</h2>
+                <v-card flat>
+                    <v-card-text>
+                        <v-avatar>
+                            <v-img :src="project.leader.memberImg"></v-img>
+                        </v-avatar>
+                        <p>{{ project.leader.memberNickname }}</p>
+                        <v-chip v-for="tech in project.leader.techStack" :key="tech" class="ma-1">
+                            {{ tech }}
+                        </v-chip>
+                    </v-card-text>
+                </v-card>
+            </v-col>
+        </v-row>
+
+        <v-row>
+            <v-col cols="12">
+                <h2>모집 현황</h2>
+                <v-list>
+                    <v-list-item v-for="recruitment in project.recruitments" :key="recruitment.jobId">
+                        <v-list-item-content>
+                            <v-list-item-title>{{ recruitment.jobName }}</v-list-item-title>
+                            <v-list-item-subtitle> {{ recruitment.members.length }} / {{ recruitment.jobCount }} </v-list-item-subtitle>
+                        </v-list-item-content>
+                    </v-list-item>
+                </v-list>
+            </v-col>
+        </v-row>
+
+        <v-row>
+            <v-col cols="12">
+                <h2>프로젝트 소개</h2>
+                <p>{{ project.description }}</p>
+            </v-col>
+        </v-row>
+
+        <v-row>
+            <v-col cols="12">
+                <h2>기술 스택</h2>
+                <v-chip v-for="tech in project.projectTechStack" :key="tech" class="ma-1">
+                    {{ tech }}
+                </v-chip>
+            </v-col>
+        </v-row>
+
+        <v-row>
+            <v-col cols="12">
+                <h2>참여 중인 멤버</h2>
+                <v-list>
+                    <v-list-item v-for="recruitment in project.recruitments" :key="recruitment.jobId">
+                        <v-list-item-content>
+                            <v-list-item-title>{{ recruitment.jobName }}</v-list-item-title>
+                            <v-list-item-group>
+                                <v-list-item v-for="member in recruitment.members" :key="member.memberId">
+                                    <v-list-item-avatar>
+                                        <v-img :src="member.memberImg"></v-img>
+                                    </v-list-item-avatar>
+                                    <v-list-item-content>
+                                        <v-list-item-title>{{ member.memberNickname }}</v-list-item-title>
+                                        <v-list-item-subtitle>
+                                            <v-chip v-for="tech in member.techStack" :key="tech" x-small class="mr-1">
+                                                {{ tech }}
+                                            </v-chip>
+                                        </v-list-item-subtitle>
+                                    </v-list-item-content>
+                                </v-list-item>
+                            </v-list-item-group>
+                        </v-list-item-content>
+                    </v-list-item>
+                </v-list>
+            </v-col>
+        </v-row>
+    </v-container>
+</template>
+
+<script>
+export default {
+    name: 'ProjectInfo',
+    props: {
+        project: {
+            type: Object,
+        },
+    },
+};
+</script>
+
+<style scoped></style>

--- a/src/components/ProjectManagement.vue
+++ b/src/components/ProjectManagement.vue
@@ -1,0 +1,20 @@
+<!--
+ * fileName       : ProejctManagement
+ * author         : JooYoon
+ * date           : 2024-08-28
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-08-28        JooYoon       최초 생성
+-->
+<template>
+    <div></div>
+</template>
+
+<script>
+export default {
+    name: 'ProjectManagement',
+};
+</script>
+
+<style scoped></style>

--- a/src/components/ProjectRetrospective.vue
+++ b/src/components/ProjectRetrospective.vue
@@ -1,0 +1,20 @@
+<!--
+ * fileName       : ProjectRetrospective
+ * author         : JooYoon
+ * date           : 2024-08-28
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-08-28        JooYoon       최초 생성
+-->
+<template>
+    <div></div>
+</template>
+
+<script>
+export default {
+    name: 'ProjectRetrospective',
+};
+</script>
+
+<style scoped></style>

--- a/src/components/project-detail/LeaderInfo.vue
+++ b/src/components/project-detail/LeaderInfo.vue
@@ -9,34 +9,44 @@
 -->
 
 <template>
-    <v-card flat class="mb-4">
-        <v-card-title>리더 정보</v-card-title>
-        <v-card-text>
-            <v-row align="center" no-gutters>
-                <v-col cols="auto" class="mr-4">
-                    <v-avatar size="48" tile>
-                        <v-img :src="leader.memberImg"></v-img>
-                    </v-avatar>
-                </v-col>
-                <v-col>
-                    <span class="subtitle-1 font-weight-bold" style="color: black">{{ leader.memberNickname }}</span>
-                    <v-btn icon :href="leader.memberGithub" target="_blank" color="black" class="ml-2">
-                        <v-icon>mdi-github</v-icon>
-                    </v-btn>
-                </v-col>
-                <v-col cols="auto">
-                    <v-btn color="brown" dark>1:1 채팅</v-btn>
-                </v-col>
-            </v-row>
-            <v-row class="mt-2" align="center" no-gutters>
-                <v-col>
-                    <v-chip v-for="tech in leader.techStack" small :key="tech" class="mr-1">
-                        {{ tech }}
-                    </v-chip>
-                </v-col>
-            </v-row>
-        </v-card-text>
-    </v-card>
+    <div>
+        <h2>리더 정보</h2>
+        <v-card flat>
+            <v-card-text>
+                <v-row align="center" no-gutters>
+                    <v-col cols="auto" class="mr-4">
+                        <v-avatar size="48" tile>
+                            <v-img :src="leader.memberImg"></v-img>
+                        </v-avatar>
+                    </v-col>
+                    <v-col>
+                        <span class="subtitle-1 font-weight-bold" style="color: black">{{ leader.memberNickname }}</span>
+                        <v-btn icon :href="leader.memberGithub" target="_blank" color="black" class="ml-2">
+                            <v-icon>mdi-github</v-icon>
+                        </v-btn>
+                    </v-col>
+                    <v-col cols="auto">
+                        <v-btn color="brown" dark>1:1 채팅</v-btn>
+                    </v-col>
+                </v-row>
+                <v-row class="mt-2" align="center" no-gutters>
+                    <v-col>
+                        <div class="d-flex flex-wrap align-center">
+                            <template v-for="tech in leader.techStack">
+                                <div v-if="tech.imgUrl" :key="tech.name" class="ma-2">
+                                    <v-avatar size="48" class="mb-1" tile>
+                                        <v-img :src="tech.imgUrl" :alt="tech.name"></v-img>
+                                    </v-avatar>
+                                    <div class="text-center">#{{ tech.name }}</div>
+                                </div>
+                                <v-chip v-else :key="tech.name" class="ma-2" outlined> #{{ tech.name }} </v-chip>
+                            </template>
+                        </div>
+                    </v-col>
+                </v-row>
+            </v-card-text>
+        </v-card>
+    </div>
 </template>
 
 <script>

--- a/src/components/project-detail/LeaderInfo.vue
+++ b/src/components/project-detail/LeaderInfo.vue
@@ -1,0 +1,53 @@
+<!--
+ * fileName       : LeaderInfo
+ * author         : JooYoon
+ * date           : 2024-08-29
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-08-29        JooYoon       최초 생성
+-->
+
+<template>
+    <v-card flat class="mb-4">
+        <v-card-title>리더 정보</v-card-title>
+        <v-card-text>
+            <v-row align="center" no-gutters>
+                <v-col cols="auto" class="mr-4">
+                    <v-avatar size="48" tile>
+                        <v-img :src="leader.memberImg"></v-img>
+                    </v-avatar>
+                </v-col>
+                <v-col>
+                    <span class="subtitle-1 font-weight-bold" style="color: black">{{ leader.memberNickname }}</span>
+                    <v-btn icon :href="leader.memberGithub" target="_blank" color="black" class="ml-2">
+                        <v-icon>mdi-github</v-icon>
+                    </v-btn>
+                </v-col>
+                <v-col cols="auto">
+                    <v-btn color="brown" dark>1:1 채팅</v-btn>
+                </v-col>
+            </v-row>
+            <v-row class="mt-2" align="center" no-gutters>
+                <v-col>
+                    <v-chip v-for="tech in leader.techStack" small :key="tech" class="mr-1">
+                        {{ tech }}
+                    </v-chip>
+                </v-col>
+            </v-row>
+        </v-card-text>
+    </v-card>
+</template>
+
+<script>
+export default {
+    name: 'LeaderInfo',
+    props: {
+        leader: {
+            type: Object,
+        },
+    },
+};
+</script>
+
+<style scoped></style>

--- a/src/components/project-detail/ProjectDescription.vue
+++ b/src/components/project-detail/ProjectDescription.vue
@@ -1,0 +1,31 @@
+<!--
+ * fileName       : ProjectDescription
+ * author         : JooYoon
+ * date           : 2024-08-29
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-08-29        JooYoon       최초 생성
+-->
+
+<template>
+    <div class="mb-4">
+        <h2>프로젝트 소개</h2>
+        <div>
+            {{ description }}
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'ProjectDescription',
+    props: {
+        description: {
+            type: String,
+        },
+    },
+};
+</script>
+
+<style scoped></style>

--- a/src/components/project-detail/ProjectInfo.vue
+++ b/src/components/project-detail/ProjectInfo.vue
@@ -15,16 +15,15 @@
 
         <recruitment-status :recruitments="project.recruitments" />
 
+        <v-divider />
+
         <project-description :description="project.description" />
 
-        <v-row>
-            <v-col cols="12">
-                <h2>기술 스택</h2>
-                <v-chip v-for="tech in project.projectTechStack" :key="tech" class="ma-1">
-                    {{ tech }}
-                </v-chip>
-            </v-col>
-        </v-row>
+        <v-divider />
+
+        <tech-stack :projectTechStack="project.projectTechStack" />
+
+        <v-divider />
 
         <v-row>
             <v-col cols="12">
@@ -60,10 +59,11 @@
 import LeaderInfo from '@/components/project-detail/LeaderInfo.vue';
 import RecruitmentStatus from '@/components/project-detail/RecruitmentStatus.vue';
 import ProjectDescription from '@/components/project-detail/ProjectDescription.vue';
+import TechStack from '@/components/project-detail/TechStack.vue';
 
 export default {
     name: 'ProjectInfo',
-    components: { ProjectDescription, RecruitmentStatus, LeaderInfo },
+    components: { TechStack, ProjectDescription, RecruitmentStatus, LeaderInfo },
     props: {
         project: {
             type: Object,

--- a/src/components/project-detail/ProjectInfo.vue
+++ b/src/components/project-detail/ProjectInfo.vue
@@ -8,50 +8,24 @@
  * 2024-08-28        JooYoon       최초 생성
 -->
 <template>
-    <div>
+    <div class="pa-4">
         <leader-info :leader="project.leader" />
 
-        <v-divider />
+        <v-divider class="my-6" />
 
         <recruitment-status :recruitments="project.recruitments" />
 
-        <v-divider />
+        <v-divider class="my-6" />
 
         <project-description :description="project.description" />
 
-        <v-divider />
+        <v-divider class="my-6" />
 
         <tech-stack :projectTechStack="project.projectTechStack" />
 
-        <v-divider />
+        <v-divider class="my-6" />
 
-        <v-row>
-            <v-col cols="12">
-                <h2>참여 중인 멤버</h2>
-                <v-list>
-                    <v-list-item v-for="recruitment in project.recruitments" :key="recruitment.jobId">
-                        <v-list-item-content>
-                            <v-list-item-title>{{ recruitment.jobName }}</v-list-item-title>
-                            <v-list-item-group>
-                                <v-list-item v-for="member in recruitment.members" :key="member.memberId">
-                                    <v-list-item-avatar>
-                                        <v-img :src="member.memberImg"></v-img>
-                                    </v-list-item-avatar>
-                                    <v-list-item-content>
-                                        <v-list-item-title>{{ member.memberNickname }}</v-list-item-title>
-                                        <v-list-item-subtitle>
-                                            <v-chip v-for="tech in member.techStack" :key="tech" x-small class="mr-1">
-                                                {{ tech }}
-                                            </v-chip>
-                                        </v-list-item-subtitle>
-                                    </v-list-item-content>
-                                </v-list-item>
-                            </v-list-item-group>
-                        </v-list-item-content>
-                    </v-list-item>
-                </v-list>
-            </v-col>
-        </v-row>
+        <project-members :recruitments="project.recruitments" />
     </div>
 </template>
 
@@ -60,10 +34,11 @@ import LeaderInfo from '@/components/project-detail/LeaderInfo.vue';
 import RecruitmentStatus from '@/components/project-detail/RecruitmentStatus.vue';
 import ProjectDescription from '@/components/project-detail/ProjectDescription.vue';
 import TechStack from '@/components/project-detail/TechStack.vue';
+import ProjectMembers from '@/components/project-detail/ProjectMembers.vue';
 
 export default {
     name: 'ProjectInfo',
-    components: { TechStack, ProjectDescription, RecruitmentStatus, LeaderInfo },
+    components: { ProjectMembers, TechStack, ProjectDescription, RecruitmentStatus, LeaderInfo },
     props: {
         project: {
             type: Object,

--- a/src/components/project-detail/ProjectInfo.vue
+++ b/src/components/project-detail/ProjectInfo.vue
@@ -8,44 +8,14 @@
  * 2024-08-28        JooYoon       최초 생성
 -->
 <template>
-    <v-container>
-        <v-row>
-            <v-col cols="12">
-                <h2>리더 정보</h2>
-                <v-card flat>
-                    <v-card-text>
-                        <v-avatar>
-                            <v-img :src="project.leader.memberImg"></v-img>
-                        </v-avatar>
-                        <p>{{ project.leader.memberNickname }}</p>
-                        <v-chip v-for="tech in project.leader.techStack" :key="tech" class="ma-1">
-                            {{ tech }}
-                        </v-chip>
-                    </v-card-text>
-                </v-card>
-            </v-col>
-        </v-row>
+    <div>
+        <leader-info :leader="project.leader" />
 
-        <v-row>
-            <v-col cols="12">
-                <h2>모집 현황</h2>
-                <v-list>
-                    <v-list-item v-for="recruitment in project.recruitments" :key="recruitment.jobId">
-                        <v-list-item-content>
-                            <v-list-item-title>{{ recruitment.jobName }}</v-list-item-title>
-                            <v-list-item-subtitle> {{ recruitment.members.length }} / {{ recruitment.jobCount }} </v-list-item-subtitle>
-                        </v-list-item-content>
-                    </v-list-item>
-                </v-list>
-            </v-col>
-        </v-row>
+        <v-divider />
 
-        <v-row>
-            <v-col cols="12">
-                <h2>프로젝트 소개</h2>
-                <p>{{ project.description }}</p>
-            </v-col>
-        </v-row>
+        <recruitment-status :recruitments="project.recruitments" />
+
+        <project-description :description="project.description" />
 
         <v-row>
             <v-col cols="12">
@@ -83,12 +53,17 @@
                 </v-list>
             </v-col>
         </v-row>
-    </v-container>
+    </div>
 </template>
 
 <script>
+import LeaderInfo from '@/components/project-detail/LeaderInfo.vue';
+import RecruitmentStatus from '@/components/project-detail/RecruitmentStatus.vue';
+import ProjectDescription from '@/components/project-detail/ProjectDescription.vue';
+
 export default {
     name: 'ProjectInfo',
+    components: { ProjectDescription, RecruitmentStatus, LeaderInfo },
     props: {
         project: {
             type: Object,

--- a/src/components/project-detail/ProjectMembers.vue
+++ b/src/components/project-detail/ProjectMembers.vue
@@ -1,0 +1,39 @@
+<!--
+ * fileName       : ProjectMembers
+ * author         : JooYoon
+ * date           : 2024-09-01
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-09-01           JooYoon           최초 생성
+-->
+
+<template>
+    <v-row>
+        <v-col cols="12">
+            <h2 class="mb-4">참여 중인 멤버</h2>
+            <div v-for="recruitment in recruitments" :key="recruitment.jobId" class="mb-4">
+                <h3 class="subtitle-1 font-weight-bold mb-2 text-h6">{{ recruitment.jobName }}</h3>
+                <div class="d-flex flex-wrap">
+                    <member-card v-for="member in recruitment.members" :key="member.memberId" :member="member" />
+                </div>
+            </div>
+        </v-col>
+    </v-row>
+</template>
+
+<script>
+import MemberCard from '@/components/MemberCard.vue';
+
+export default {
+    name: 'ProjectMembers',
+    components: { MemberCard },
+    props: {
+        recruitments: {
+            type: Array,
+        },
+    },
+};
+</script>
+
+<style scoped></style>

--- a/src/components/project-detail/RecruitmentStatus.vue
+++ b/src/components/project-detail/RecruitmentStatus.vue
@@ -1,0 +1,40 @@
+<!--
+ * fileName       : RecruitmentStatus
+ * author         : JooYoon
+ * date           : 2024-08-29
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-08-29        JooYoon       최초 생성
+-->
+
+<template>
+    <v-card flat class="mb-4">
+        <v-card-title>모집 현황</v-card-title>
+        <v-card-text>
+            <v-row>
+                <v-col v-for="recruitment in recruitments" :key="recruitment.jobId" cols="2">
+                    <v-card outlined class="text-center" rounded>
+                        <v-card-text style="color: black">
+                            <div class="text-h6 mb-2">{{ recruitment.jobName }}</div>
+                            <div class="text-subtitle-1">{{ recruitment.members.length }} / {{ recruitment.jobCount }}</div>
+                        </v-card-text>
+                    </v-card>
+                </v-col>
+            </v-row>
+        </v-card-text>
+    </v-card>
+</template>
+
+<script>
+export default {
+    name: 'RecruitmentStatus',
+    props: {
+        recruitments: {
+            type: Array,
+        },
+    },
+};
+</script>
+
+<style scoped></style>

--- a/src/components/project-detail/RecruitmentStatus.vue
+++ b/src/components/project-detail/RecruitmentStatus.vue
@@ -9,21 +9,23 @@
 -->
 
 <template>
-    <v-card flat class="mb-4">
-        <v-card-title>모집 현황</v-card-title>
-        <v-card-text>
-            <v-row>
-                <v-col v-for="recruitment in recruitments" :key="recruitment.jobId" cols="2">
-                    <v-card outlined class="text-center" rounded>
-                        <v-card-text style="color: black">
-                            <div class="text-h6 mb-2">{{ recruitment.jobName }}</div>
-                            <div class="text-subtitle-1">{{ recruitment.members.length }} / {{ recruitment.jobCount }}</div>
-                        </v-card-text>
-                    </v-card>
-                </v-col>
-            </v-row>
-        </v-card-text>
-    </v-card>
+    <div>
+        <h2>모집 현황</h2>
+        <v-card flat>
+            <v-card-text>
+                <v-row>
+                    <v-col v-for="recruitment in recruitments" :key="recruitment.jobId" cols="2">
+                        <v-card outlined class="text-center" rounded>
+                            <v-card-text style="color: black">
+                                <div class="text-h6 mb-2">{{ recruitment.jobName }}</div>
+                                <div class="text-subtitle-1">{{ recruitment.members.length }} / {{ recruitment.jobCount }}</div>
+                            </v-card-text>
+                        </v-card>
+                    </v-col>
+                </v-row>
+            </v-card-text>
+        </v-card>
+    </div>
 </template>
 
 <script>

--- a/src/components/project-detail/TechStack.vue
+++ b/src/components/project-detail/TechStack.vue
@@ -1,0 +1,41 @@
+<!--
+ * fileName       : TechStack
+ * author         : JooYoon
+ * date           : 2024-08-30
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-08-30        JooYoon       최초 생성
+-->
+
+<template>
+    <v-row>
+        <v-col cols="12">
+            <h2>기술 스택</h2>
+            <div class="d-flex flex-wrap align-center">
+                <template v-for="tech in projectTechStack">
+                    <div v-if="tech.imgUrl" :key="tech.name" class="ma-2">
+                        <v-avatar size="48" class="mb-1" tile>
+                            <v-img :src="tech.imgUrl" :alt="tech.name"></v-img>
+                        </v-avatar>
+                        <div class="text-center">#{{ tech.name }}</div>
+                    </div>
+                    <v-chip v-else :key="tech.name" class="ma-2" outlined> #{{ tech.name }} </v-chip>
+                </template>
+            </div>
+        </v-col>
+    </v-row>
+</template>
+
+<script>
+export default {
+    name: 'TechStack',
+    props: {
+        projectTechStack: {
+            type: Array,
+        },
+    },
+};
+</script>
+
+<style scoped></style>

--- a/src/router/route.js
+++ b/src/router/route.js
@@ -1,9 +1,16 @@
-import TestCompo from "@/components/TestCompo.vue";
+import TestCompo from '@/components/TestCompo.vue';
+import ProjectDetailPage from '@/views/ProjectDetailPage.vue';
 
 export default [
-  {
-    path: "/",
-    name: "TestCompo",
-    component: TestCompo,
-  },
+    {
+        path: '/',
+        name: 'TestCompo',
+        component: TestCompo,
+    },
+
+    {
+        path: '/projects/:projectId',
+        name: 'ProjectDetail',
+        component: ProjectDetailPage,
+    },
 ];

--- a/src/views/ProjectDetailPage.vue
+++ b/src/views/ProjectDetailPage.vue
@@ -1,0 +1,114 @@
+<!--
+ * fileName       : ProjectDetailPage
+ * author         : JooYoon
+ * date           : 2024-08-28
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-08-28        JooYoon       최초 생성
+-->
+<template>
+    <v-container>
+        <v-row>
+            <v-col cols="12">
+                <h1>{{ project.name }}</h1>
+                <v-chip :color="getStatusColor(project.status)" text-color="white">
+                    {{ getStatusText(project.status) }}
+                </v-chip>
+            </v-col>
+        </v-row>
+
+        <v-row v-if="project.status === 1">
+            <v-col cols="12">
+                <v-progress-linear :value="getProgressValue()" height="25" striped></v-progress-linear>
+            </v-col>
+        </v-row>
+
+        <v-tabs v-model="activeTab">
+            <v-tab>정보</v-tab>
+            <v-tab>회고</v-tab>
+            <v-tab>관리</v-tab>
+        </v-tabs>
+
+        <v-tabs-items v-model="activeTab">
+            <v-tab-item>
+                <project-info :project="project"></project-info>
+            </v-tab-item>
+            <v-tab-item>
+                <project-retrospective></project-retrospective>
+            </v-tab-item>
+            <v-tab-item>
+                <project-management></project-management>
+            </v-tab-item>
+        </v-tabs-items>
+    </v-container>
+</template>
+
+<script>
+import ProjectInfo from '@/components/ProjectInfo.vue';
+import ProjectRetrospective from '@/components/ProjectRetrospective.vue';
+import ProjectManagement from '@/components/ProjectManagement.vue';
+
+export default {
+    name: 'ProjectDetailPage',
+    components: { ProjectManagement, ProjectInfo, ProjectRetrospective },
+    data() {
+        return {
+            project: {},
+            activeTab: 0,
+        };
+    },
+    created() {
+        this.fetchProjectDetails();
+    },
+    methods: {
+        async fetchProjectDetails() {
+            try {
+                const response = await this.$axios.get(`/api/projects/${this.$route.params.projectId}`);
+                this.project = response.data;
+            } catch (error) {
+                console.error('Error fetching project details:', error);
+            }
+        },
+        getStatusColor(status) {
+            switch (status) {
+                case 0:
+                    return 'green';
+                case 1:
+                    return 'blue';
+                case 2:
+                    return 'grey';
+            }
+        },
+        getStatusText(status) {
+            switch (status) {
+                case 0:
+                    return '모집 중';
+                case 1:
+                    return '진행 중';
+                case 2:
+                    return '종료';
+            }
+        },
+        getProgressValue() {
+            if (!this.project.startedAt || !this.project.duration) {
+                return 0;
+            }
+
+            const startDate = new Date(this.project.startedAt);
+            const endDate = new Date(startDate.getTime() + this.project.duration * 24 * 60 * 60 * 1000);
+            const currentDate = new Date();
+
+            if (currentDate >= endDate) {
+                return 100;
+            }
+
+            const totalDuration = endDate - startDate;
+            const elapsedDuration = currentDate - startDate;
+            return Math.round((elapsedDuration / totalDuration) * 100);
+        },
+    },
+};
+</script>
+
+<style scoped></style>

--- a/src/views/ProjectDetailPage.vue
+++ b/src/views/ProjectDetailPage.vue
@@ -20,6 +20,7 @@
 
         <v-row v-if="project.status === 1">
             <v-col cols="12">
+                <p>프로젝트 진행도</p>
                 <v-progress-linear :value="getProgressValue()" height="25" striped></v-progress-linear>
             </v-col>
         </v-row>
@@ -45,7 +46,7 @@
 </template>
 
 <script>
-import ProjectInfo from '@/components/ProjectInfo.vue';
+import ProjectInfo from '@/components/project-detail/ProjectInfo.vue';
 import ProjectRetrospective from '@/components/ProjectRetrospective.vue';
 import ProjectManagement from '@/components/ProjectManagement.vue';
 

--- a/src/views/ProjectDetailPage.vue
+++ b/src/views/ProjectDetailPage.vue
@@ -9,23 +9,29 @@
 -->
 <template>
     <v-container>
-        <v-row>
-            <v-col cols="12">
-                <h1>{{ project.name }}</h1>
+        <v-row justify="center" align="center">
+            <v-col cols="12" class="text-center">
+                <h1 class="ma-2">{{ project.name }}</h1>
                 <v-chip :color="getStatusColor(project.status)" text-color="white">
                     {{ getStatusText(project.status) }}
                 </v-chip>
             </v-col>
         </v-row>
 
-        <v-row v-if="project.status === 1">
-            <v-col cols="12">
-                <p>프로젝트 진행도</p>
-                <v-progress-linear :value="getProgressValue()" height="25" striped></v-progress-linear>
+        <v-row v-if="project.status === 1" justify="center">
+            <v-col cols="12" sm="8" md="6" lg="4">
+                <div class="position-relative ma-10">
+                    <div class="date-labels d-flex justify-space-between mb-1">
+                        <span class="caption">{{ formatDate(startDate) }}</span>
+                        <span class="caption">{{ formatDate(currentDate) }}</span>
+                        <span class="caption">{{ formatDate(endDate) }}</span>
+                    </div>
+                    <v-progress-linear :value="progressValue" color="brown" height="5"></v-progress-linear>
+                </div>
             </v-col>
         </v-row>
 
-        <v-tabs v-model="activeTab">
+        <v-tabs v-model="activeTab" class="mt-10">
             <v-tab>정보</v-tab>
             <v-tab>회고</v-tab>
             <v-tab>관리</v-tab>
@@ -59,6 +65,30 @@ export default {
             activeTab: 0,
         };
     },
+    computed: {
+        startDate() {
+            return new Date(this.project.startedAt);
+        },
+        endDate() {
+            return new Date(this.startDate.getTime() + this.project.duration * 7 * 24 * 60 * 60 * 1000);
+        },
+        currentDate() {
+            return new Date();
+        },
+        progressValue() {
+            if (!this.project.startedAt || !this.project.duration) {
+                return 0;
+            }
+
+            if (this.currentDate >= this.endDate) {
+                return 100;
+            }
+
+            const totalDuration = this.endDate - this.startDate;
+            const elapsedDuration = this.currentDate - this.startDate;
+            return Math.round((elapsedDuration / totalDuration) * 100);
+        },
+    },
     created() {
         this.fetchProjectDetails();
     },
@@ -91,25 +121,22 @@ export default {
                     return '종료';
             }
         },
-        getProgressValue() {
-            if (!this.project.startedAt || !this.project.duration) {
-                return 0;
-            }
 
-            const startDate = new Date(this.project.startedAt);
-            const endDate = new Date(startDate.getTime() + this.project.duration * 24 * 60 * 60 * 1000);
-            const currentDate = new Date();
-
-            if (currentDate >= endDate) {
-                return 100;
-            }
-
-            const totalDuration = endDate - startDate;
-            const elapsedDuration = currentDate - startDate;
-            return Math.round((elapsedDuration / totalDuration) * 100);
+        formatDate(date) {
+            return date.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
         },
     },
 };
 </script>
 
-<style scoped></style>
+<style scoped>
+.position-relative {
+    position: relative;
+}
+
+.date-labels {
+    position: absolute;
+    width: 100%;
+    top: -20px;
+}
+</style>


### PR DESCRIPTION
## 📌 변경 사항
### AS-IS


### TO-BE
- 프로젝트 상세 페이지를 위한 ProjectDetailPage와 해당 페이지에 들어가는 ProjectInfo, ProjectManagement, ProjectRetrospective 컴포넌트 생성
  - ProjectInfo에 들어가는 LeaderInfo, RecruitmentStatus, ProjectDescription, TechStack, ProjectMembers 컴포넌트 생성
- 프로젝트 상세 페이지의 정보탭과 관리탭, 유저 검색 페이지, 통합 검색 페이지에서 사용되는 MemberCard 컴포넌트 생성

## 📌 테스트
- [ ] 테스트 코드
- [x] API 테스트
