### PR TITLE
refactor/kyh/project_application

### DIFF
--- a/src/components/project-detail/ProjectManagement.vue
+++ b/src/components/project-detail/ProjectManagement.vue
@@ -84,6 +84,7 @@ export default {
         async fetchApproval(member, value) {
             const data = {
                 projectId: this.$route.params.projectId,
+                jobId: member.jobId,
                 memberId: member.projectMemberId,
                 acceptStatus: value,
             };

--- a/src/components/project-detail/RecruitmentStatus.vue
+++ b/src/components/project-detail/RecruitmentStatus.vue
@@ -78,9 +78,13 @@ export default {
     methods: {
         async applyForProject(jobId) {
             try {
-                await this.$axiosInstance.post(`/api/projects/${this.projectId}/applications`, {
-                    jobId: jobId,
-                });
+                await this.$axiosInstance.post(
+                    `/api/projects/${this.projectId}/applications`,
+                    {
+                        jobId: jobId,
+                    },
+                    { context: this },
+                );
 
                 this.resultHeader = '지원 완료';
                 this.resultContent = '프로젝트 지원완료';


### PR DESCRIPTION
## 📌 변경 사항
- [x]  이미 프로젝트 지원중이라면, 다른 직무로도 지원할 수 없어야 한다. - yh
- [x]  이미 지원이 거절된 이력이 존재하여도, 새로운 지원요청을 거절할 수 있어야한다. - yh
- [x]  프로젝트 지원 실패(오류발생)시 모달창이 안뜨는 문제 -yh
    - [ ]  이미 지원중이거나 승인된 상태일 때 거절 모달 출력인데 현재 메세지가 
    동일함(”이미 지원중입니다.”) → 시간 남으면 바꿀예정 - yh
<br>

